### PR TITLE
click 8.0.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,8 @@ requirements:
   host:
     - python >=3.6
     - pip
+    - setuptools
+    - wheel
   run:
     - python >=3.6
     - colorama  # [win]
@@ -25,6 +27,12 @@ requirements:
 test:
   imports:
     - click
+  requires:
+    - pip
+    - python <3.10
+  commands:
+    # temporarily skipping pip check on win and pypy build because of bizarre tqdm issue
+    - pip check  # [not (win and python_impl == 'pypy')]
 
 about:
   home: https://palletsprojects.com/p/click

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.0.1" %}
+{% set version = "8.0.3" %}
 
 package:
   name: click
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/click/click-{{ version }}.tar.gz
-  sha256: 8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a
+  sha256: 410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ test:
   requires:
     - pip
     - python <3.10
+    - colorama  # [win]
   commands:
     # temporarily skipping pip check on win and pypy build because of bizarre tqdm issue
     - pip check  # [not (win and python_impl == 'pypy')]


### PR DESCRIPTION
Category:  anaconda | subcategory:  dependency | pkg_type:  python
Popularity:  10069101 downloads -  click  8.0.3  Python composable command line interface toolkit
Version change: bump version number from 8.0.1 to 8.0.3
  license: BSD-3-Clause
Release date:  Oct 10, 2021
Bug Tracker: new open issues https://github.com/pallets/click/issues
The License: https://github.com/pallets/click/blob/main/LICENSE.rst
Upstream Changelog: https://github.com/pallets/click/blob/main/CHANGES.rst
Upstream setup.py:  https://github.com/pallets/click/blob/main/setup.py

The package click is mentioned inside the packages:
archspec | celery | clickclick | click-didyoumean | click-plugins | click-repl | cligj | conda-verify | cookiecutter | cubes | distributed | fiona | flask | flask-appbuilder | google-auth-oauthlib | hypothesis | moto | nltk | rasterio | ray-packages | typer |

Actions:
1. Add missing packages: `setuptools`, `wheel`
2. Add `pip check` in the test section
3. Add `python <3.10` in the test/requires section

Result:
- all-succeeded
