### PR TITLE
click 8.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.0.3" %}
+{% set version = "8.0.4" %}
 
 package:
   name: click
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/click/click-{{ version }}.tar.gz
-  sha256: 410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b
+  sha256: 8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,36 +1,35 @@
+{% set name = "click" %}
 {% set version = "8.0.4" %}
 
 package:
-  name: click
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/c/click/click-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/click-{{ version }}.tar.gz
   sha256: 8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools
-    - wheel
+    - wheels
   run:
-    - python >=3.6
+    - python
     - colorama  # [win]
-    - importlib-metadata  #[py<38]
+    - importlib-metadata  # [py<38]
 
 test:
   imports:
     - click
   requires:
     - pip
-    - python <3.10
-    - colorama  # [win]
   commands:
     # temporarily skipping pip check on win and pypy build because of bizarre tqdm issue
     - pip check  # [not (win and python_impl == 'pypy')]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - wheels
+    - wheel
   run:
     - python
     - colorama  # [win]


### PR DESCRIPTION
Update click to 8.0.4

Bug Tracker: new open issues https://github.com/pallets/click/issues
The License: https://github.com/pallets/click/blob/main/LICENSE.rst
Upstream Changelog: https://github.com/pallets/click/blob/main/CHANGES.rst
Upstream setup.py: https://github.com/pallets/click/blob/8.0.4/setup.py

Actions:
1. Remove n`oarch`
2. Skip p`y<36`, https://github.com/pallets/click/blob/main/CHANGES.rst#version-800
3. Remove `python `and `colorama `from `test/requires`

Result:

all-succeeded